### PR TITLE
Fix bounds check in set pixel function

### DIFF
--- a/blinky.js
+++ b/blinky.js
@@ -33,7 +33,7 @@ function Blinky(port) {
 util.inherits(Blinky, EventEmitter);
 
 Blinky.prototype.setPixel = function(pixelIndex, r, g, b) {
-  if (pixelIndex > 60 || pixelIndex < 0) {
+  if (pixelIndex >= 60 || pixelIndex < 0) {
     return;
   }
 


### PR DESCRIPTION
There is a small bug which allows you to accidentally overwrite the control terminator at the end of the buffer. If you do this then the tape fails to update.
